### PR TITLE
fix: Incorrect input handling in dummy vgui panel

### DIFF
--- a/imgui/imgui_system.cpp
+++ b/imgui/imgui_system.cpp
@@ -188,18 +188,17 @@ public:
 			io.AddInputCharacter( code );
 	}
 	
+	// always pass keycodes to imgui, WantCaptureKeyboard should NOT affect whether or not we do this
 	void OnKeyCodePressed( vgui::KeyCode code ) override
 	{
 		auto& io = ImGui::GetIO();
-		if ( io.WantCaptureKeyboard )
-			io.AddKeyEvent( IMGUI_KEY_TABLE[code], true );
+		io.AddKeyEvent( IMGUI_KEY_TABLE[code], true );
 	}
 	
 	void OnKeyCodeReleased( vgui::KeyCode code ) override
 	{
 		auto& io = ImGui::GetIO();
-		if ( io.WantCaptureKeyboard )
-			io.AddKeyEvent( IMGUI_KEY_TABLE[code], false );
+		io.AddKeyEvent( IMGUI_KEY_TABLE[code], false );
 	}
 	
 	void Paint() override


### PR DESCRIPTION
`io.WantCaptureKeyboard` should not affect whether or not you're passing keys, ALWAYS pass them or else some keys can be pressed and never released on ImGui side.

examples of this issue:
- enter key on input field
- any key that defocuses a field

Comment for `io.WantCaptureKeyboard` contains the following:
> always pass keyboard inputs to ImGui
